### PR TITLE
Update tag.py

### DIFF
--- a/adv_cache_tag/tag.py
+++ b/adv_cache_tag/tag.py
@@ -9,7 +9,11 @@ import zlib
 from django import VERSION as django_version
 from django.conf import settings
 from django.utils.encoding import smart_str, force_bytes
-from django.utils.http import urlquote
+
+if django_version >= (4,0):
+    from urllib.parse import quote
+else:
+    from django.utils.http import urlquote
 
 from .compat import get_cache, get_template_libraries, template
 
@@ -301,7 +305,10 @@ class CacheTag(object, metaclass=CacheTagMetaClass):
         Take all the arguments passed after the fragment name and return a
         hashed version which will be used in the cache key
         """
-        return hashlib.md5(force_bytes(':'.join([urlquote(force_bytes(var)) for var in self.vary_on]))).hexdigest()
+        if django_version >= (4,0):
+            return hashlib.md5(force_bytes(':'.join([quote(force_bytes(var)) for var in self.vary_on]))).hexdigest()
+        else:
+            return hashlib.md5(force_bytes(':'.join([urlquote(force_bytes(var)) for var in self.vary_on]))).hexdigest()
 
     def get_pk(self):
         """


### PR DESCRIPTION
Adding Django 4.x compatibility. 
django.utils.http.urlquote no longer supported.
urllib.parse.quote required for 4.x

Change imports to test django_version, import appropriate module. Add similar test to CacheTag.hash_args() to call appropriate module.